### PR TITLE
User callbacks

### DIFF
--- a/include/netstack.h
+++ b/include/netstack.h
@@ -23,25 +23,46 @@ extern "C" {
 
 struct netstack;
 
+typedef struct netstack_iface {
+  struct ifinfomsg ifi;
+  char name[IFNAMSIZ];
+  // FIXME
+} netstack_iface;
+
+// Callback types for various events. Even though routes, addresses etc. can be
+// reached through a netstack_iface object, they each get their own type of
+// callback.
+typedef int(*netstack_iface_cb)(const netstack_iface*, void*);
+
 // The default for all members is false or the appropriate zero representation.
 typedef struct netstack_opts {
   // refrain from launching a thread to handle netlink events in the
   // background. caller will need to handle nonblocking I/O.
   bool no_thread;
+  // if a given callback is NULL, the default will be used (print to stdout)
+  netstack_iface_cb iface_cb;
 } netstack_opts;
 
 // Opts may be NULL, in which case the defaults will be used.
 struct netstack* netstack_create(const netstack_opts* opts);
 int netstack_destroy(struct netstack* ns);
 
-typedef struct netstack_dev {
-  char name[IFNAMSIZ];
-} netstack_dev;
+typedef struct netstack_addr {
+  struct ifaddrmsg ifa;
+  // FIXME
+} netstack_addr;
 
-// Callback type for netstack_foreach_dev().
-typedef int(*netstackcb)(const netstack_dev*, void*);
+typedef struct netstack_route {
+  struct rtmsg rt;
+  // FIXME
+} netstack_route;
 
-int netstack_foreach_dev(struct netstack* ns, void* curry);
+typedef struct netstack_neigh {
+  struct ndmsg nd;
+  // FIXME
+} netstack_neigh;
+
+int netstack_print_iface(const netstack_iface* ni, FILE* out);
 
 #ifdef __cplusplus
 }

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -3,6 +3,7 @@
 
 #include <net/if.h>
 #include <stdbool.h>
+#include <linux/rtnetlink.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -30,26 +30,6 @@ typedef struct netstack_iface {
   // FIXME
 } netstack_iface;
 
-// Callback types for various events. Even though routes, addresses etc. can be
-// reached through a netstack_iface object, they each get their own type of
-// callback.
-typedef void (*netstack_iface_cb)(const netstack_iface*, void*);
-
-// The default for all members is false or the appropriate zero representation.
-typedef struct netstack_opts {
-  // refrain from launching a thread to handle netlink events in the
-  // background. caller will need to handle nonblocking I/O.
-  bool no_thread;
-  // if a given callback is NULL, the default will be used (print to stdout).
-  // a given curry may be non-NULL only if the corresponding cb is also NULL.
-  netstack_iface_cb iface_cb;
-  void* iface_curry;
-} netstack_opts;
-
-// Opts may be NULL, in which case the defaults will be used.
-struct netstack* netstack_create(const netstack_opts* opts);
-int netstack_destroy(struct netstack* ns);
-
 typedef struct netstack_addr {
   struct ifaddrmsg ifa;
   // FIXME
@@ -64,6 +44,35 @@ typedef struct netstack_neigh {
   struct ndmsg nd;
   // FIXME
 } netstack_neigh;
+
+// Callback types for various events. Even though routes, addresses etc. can be
+// reached through a netstack_iface object, they each get their own type of
+// callback.
+typedef void (*netstack_iface_cb)(const netstack_iface*, void*);
+typedef void (*netstack_addr_cb)(const netstack_addr*, void*);
+typedef void (*netstack_route_cb)(const netstack_route*, void*);
+typedef void (*netstack_neigh_cb)(const netstack_neigh*, void*);
+
+// The default for all members is false or the appropriate zero representation.
+typedef struct netstack_opts {
+  // refrain from launching a thread to handle netlink events in the
+  // background. caller will need to handle nonblocking I/O.
+  bool no_thread;
+  // if a given callback is NULL, the default will be used (print to stdout).
+  // a given curry may be non-NULL only if the corresponding cb is also NULL.
+  netstack_iface_cb iface_cb;
+  void* iface_curry;
+  netstack_addr_cb addr_cb;
+  void* addr_curry;
+  netstack_route_cb route_cb;
+  void* route_curry;
+  netstack_neigh_cb neigh_cb;
+  void* neigh_curry;
+} netstack_opts;
+
+// Opts may be NULL, in which case the defaults will be used.
+struct netstack* netstack_create(const netstack_opts* opts);
+int netstack_destroy(struct netstack* ns);
 
 int netstack_print_iface(const netstack_iface* ni, FILE* out);
 

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -33,7 +33,7 @@ typedef struct netstack_iface {
 // Callback types for various events. Even though routes, addresses etc. can be
 // reached through a netstack_iface object, they each get their own type of
 // callback.
-typedef int(*netstack_iface_cb)(const netstack_iface*, void*);
+typedef void (*netstack_iface_cb)(const netstack_iface*, void*);
 
 // The default for all members is false or the appropriate zero representation.
 typedef struct netstack_opts {

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -75,6 +75,9 @@ struct netstack* netstack_create(const netstack_opts* opts);
 int netstack_destroy(struct netstack* ns);
 
 int netstack_print_iface(const netstack_iface* ni, FILE* out);
+int netstack_print_addr(const netstack_addr* na, FILE* out);
+int netstack_print_route(const netstack_route* nr, FILE* out);
+int netstack_print_neigh(const netstack_neigh* nn, FILE* out);
 
 #ifdef __cplusplus
 }

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -40,8 +40,10 @@ typedef struct netstack_opts {
   // refrain from launching a thread to handle netlink events in the
   // background. caller will need to handle nonblocking I/O.
   bool no_thread;
-  // if a given callback is NULL, the default will be used (print to stdout)
+  // if a given callback is NULL, the default will be used (print to stdout).
+  // a given curry may be non-NULL only if the corresponding cb is also NULL.
   netstack_iface_cb iface_cb;
+  void* iface_curry;
 } netstack_opts;
 
 // Opts may be NULL, in which case the defaults will be used.

--- a/src/lib/netstack.c
+++ b/src/lib/netstack.c
@@ -254,6 +254,21 @@ viface_cb(const netstack* ns, const void* vni){
   ns->opts.iface_cb(vni, ns->opts.iface_curry);
 }
 
+static inline void
+vaddr_cb(const netstack* ns, const void* vna){
+  ns->opts.addr_cb(vna, ns->opts.addr_curry);
+}
+
+static inline void
+vroute_cb(const netstack* ns, const void* vnr){
+  ns->opts.route_cb(vnr, ns->opts.route_curry);
+}
+
+static inline void
+vneigh_cb(const netstack* ns, const void* vnn){
+  ns->opts.neigh_cb(vnn, ns->opts.neigh_curry);
+}
+
 static int
 msg_handler_internal(struct nl_msg* msg, const netstack* ns){
   struct nlmsghdr* nhdr = nlmsg_hdr(msg);
@@ -289,7 +304,7 @@ msg_handler_internal(struct nl_msg* msg, const netstack* ns){
         hdrsize = sizeof(*ifa);
         pfxn = vaddr_rta_handler;
         dfxn = vfree_addr;
-        // FIXME cfxn
+        cfxn = vaddr_cb;
         newobj = create_addr();
         break;
       case RTM_NEWROUTE:
@@ -298,7 +313,7 @@ msg_handler_internal(struct nl_msg* msg, const netstack* ns){
         hdrsize = sizeof(*rt);
         pfxn = vroute_rta_handler;
         dfxn = vfree_route;
-        // FIXME cfxn
+        cfxn = vroute_cb;
         newobj = create_route();
         break;
       case RTM_NEWNEIGH:
@@ -307,7 +322,7 @@ msg_handler_internal(struct nl_msg* msg, const netstack* ns){
         hdrsize = sizeof(*nd);
         pfxn = vneigh_rta_handler;
         dfxn = vfree_neigh;
-        // FIXME cfxn
+        cfxn = vneigh_cb;
         newobj = create_neigh();
         break;
       default: fprintf(stderr, "Unknown nl type: %d\n", ntype); break;

--- a/src/lib/netstack.c
+++ b/src/lib/netstack.c
@@ -30,27 +30,6 @@ typedef struct netstack {
   atomic_bool clear_to_send;
 } netstack;
 
-typedef struct netstack_iface {
-  char name[IFNAMSIZ];
-  // FIXME
-  struct ifinfomsg ifi;
-} netstack_iface;
-
-typedef struct netstack_addr {
-  struct ifaddrmsg ifa;
-  // FIXME
-} netstack_addr;
-
-typedef struct netstack_route {
-  struct rtmsg rt;
-  // FIXME
-} netstack_route;
-
-typedef struct netstack_neigh {
-  struct ndmsg nd;
-  // FIXME
-} netstack_neigh;
-
 // Sits on blocking nl_recvmsgs()
 static void*
 netstack_rx_thread(void* vns){
@@ -475,5 +454,11 @@ int netstack_destroy(netstack* ns){
     nl_socket_free(ns->nl);
     free(ns);
   }
+  return ret;
+}
+
+int netstack_print_iface(const netstack_iface* ni, FILE* out){
+  int ret = 0;
+  ret = fprintf(out, "[%s]\n", ni->name); // FIXME
   return ret;
 }

--- a/tests/netstack.cpp
+++ b/tests/netstack.cpp
@@ -13,3 +13,11 @@ TEST(Netstack, CreateDefaultOpts){
   ASSERT_NE(nullptr, ns);
   ASSERT_EQ(0, netstack_destroy(ns));
 }
+
+TEST(Netstack, RefuseCurryWithoutCB){
+  netstack_opts nopts;
+  memset(&nopts, 0, sizeof(nopts));
+  nopts.iface_curry = &nopts;
+  struct netstack* ns = netstack_create(&nopts);
+  ASSERT_EQ(nullptr, ns);
+}


### PR DESCRIPTION
* Allow the user to provide a callback and curry for each type (#7)
* Do not allow a curry to be specified in the absence of a callback
* Provide a printer for each type of object, use as default callback