### PR TITLE
Add name-based trie lookup (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # libnetstack
-Small C library for networking stack query / events
+A small C library for tracking and querying the local networking stack
 
 by Nick Black <dankamongmen@gmail.com>
 

--- a/tests/idxlookup.cpp
+++ b/tests/idxlookup.cpp
@@ -14,7 +14,8 @@ struct copycurry {
 
 // Sets up the callback subject interface to be copied or shared by a thread
 // external to the libnetstack event engine.
-void ExternalCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
+static void
+ExternalCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
   if(etype != NETSTACK_MOD){
     return;
   }
@@ -26,7 +27,7 @@ void ExternalCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
 }
 
 // Test deep copying of an interface from outside of its callback context
-TEST(CopyIface, IfaceDeepCopy) {
+TEST(IdxLookup, IfaceDeepCopy) {
   struct copycurry cc = { .idx = -1 };
   netstack_opts nopts;
   memset(&nopts, 0, sizeof(nopts));
@@ -52,8 +53,8 @@ TEST(CopyIface, IfaceDeepCopy) {
   netstack_iface_abandon(ni); // we should still be able to use it
 }
 
-// Test shring of an interface from outside of its callback context
-TEST(CopyIface, IfaceShare) {
+// Test sharing of an interface from outside of its callback context
+TEST(IdxLookup, IfaceShare) {
   struct copycurry cc = { .idx = -1 };
   netstack_opts nopts;
   memset(&nopts, 0, sizeof(nopts));

--- a/tests/intcopy.cpp
+++ b/tests/intcopy.cpp
@@ -15,7 +15,8 @@ struct copycurry {
 
 // Sets up the callback subject interface to be copied by the callback itself,
 // then handed to an external thread.
-void IntCopyCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
+static void
+IntCopyCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
   if(etype != NETSTACK_MOD){
     return;
   }
@@ -28,7 +29,8 @@ void IntCopyCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
   cc->mcond.notify_all();
 }
 
-void IntShareCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
+static void
+IntShareCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
   if(etype != NETSTACK_MOD){
     return;
   }

--- a/tests/namelookup.cpp
+++ b/tests/namelookup.cpp
@@ -1,0 +1,79 @@
+#include <mutex>
+#include <net/if.h>
+#include <condition_variable>
+#include "main.h"
+
+// Unit tests for copying/sharing objects previously registered via callback,
+// from outside of the callback context.
+
+// stashes the index of the callback subject interface
+struct copycurry {
+  std::mutex mlock;
+  std::condition_variable mcond;
+  std::string name;
+};
+
+// Sets up the callback subject interface to be copied or shared by a thread
+// external to the libnetstack event engine.
+static void
+ExternalCB(const netstack_iface* ni, netstack_event_e etype, void* curry) {
+  if(etype != NETSTACK_MOD){
+    return;
+  }
+  struct copycurry* cc = static_cast<struct copycurry*>(curry);
+  cc->mlock.lock();
+  char buf[IFNAMSIZ];
+  cc->name = netstack_iface_name(ni, buf);
+  cc->mlock.unlock();
+  cc->mcond.notify_all();
+}
+
+// Test name lookup + copy of an interface from outside of its callback context
+TEST(NameLookup, IfaceDeepCopy) {
+  struct copycurry cc = { .name = "", };
+  netstack_opts nopts;
+  memset(&nopts, 0, sizeof(nopts));
+  nopts.iface_cb = ExternalCB;
+  nopts.iface_curry = &cc;
+  struct netstack* ns = netstack_create(&nopts);
+  ASSERT_NE(nullptr, ns);
+  std::unique_lock<std::mutex> lck(cc.mlock);
+  cc.mcond.wait(lck, [&cc]{ return cc.name != ""; });
+  netstack_iface* ni = netstack_iface_copy_byname(ns, cc.name.c_str());
+  ASSERT_NE(nullptr, ni);
+  int idx = netstack_iface_index(ni);
+  netstack_iface* ni2 = netstack_iface_copy_byname(ns, cc.name.c_str());
+  ASSERT_NE(nullptr, ni2);
+  int idx2 = netstack_iface_index(ni2);
+  ASSERT_NE(ni, ni2);
+  ASSERT_EQ(idx, idx2);
+  netstack_iface_abandon(ni2);
+  cc.mlock.unlock();
+  ASSERT_EQ(0, netstack_destroy(ns));
+  netstack_iface_abandon(ni); // we should still be able to use it
+}
+
+// Test name lookup + share of an interface from outside of its callback context
+TEST(NameLookup, IfaceShare) {
+  struct copycurry cc = { .name = "", };
+  netstack_opts nopts;
+  memset(&nopts, 0, sizeof(nopts));
+  nopts.iface_cb = ExternalCB;
+  nopts.iface_curry = &cc;
+  struct netstack* ns = netstack_create(&nopts);
+  ASSERT_NE(nullptr, ns);
+  std::unique_lock<std::mutex> lck(cc.mlock);
+  cc.mcond.wait(lck, [&cc]{ return cc.name != ""; });
+  const netstack_iface* ni = netstack_iface_share_byname(ns, cc.name.c_str());
+  ASSERT_NE(nullptr, ni);
+  int idx = netstack_iface_index(ni);
+  const netstack_iface* ni2 = netstack_iface_share_byname(ns, cc.name.c_str());
+  ASSERT_NE(nullptr, ni2);
+  int idx2 = netstack_iface_index(ni2);
+  ASSERT_EQ(ni, ni2);
+  ASSERT_EQ(idx, idx2);
+  netstack_iface_abandon(ni2);
+  cc.mlock.unlock();
+  ASSERT_EQ(0, netstack_destroy(ns));
+  netstack_iface_abandon(ni); // we should still be able to use it
+}


### PR DESCRIPTION
* Add `name_trie` to `netstack`, support name-based lookups (#13)
* Clean up trie in `netstack_delete()`
* Unit tests for name-based lookup