### PR TITLE
Clean caches on NETSTACK_DEL events

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,6 @@ typedef struct netstack_opts {
   void* neigh_curry;
   int initial_events; // policy regarding initial object enumeration events:
                       // one of NETSTACK_INITIAL_EVENTS_{ASYNC, BLOCK, NONE}
-  // refrain from launching a thread to handle netlink events in the
-  // background. caller will need to handle nonblocking I/O. not yet used FIXME
-  bool no_thread;
 } netstack_opts;
 ```
 

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -220,9 +220,6 @@ typedef struct netstack_opts {
   netstack_neigh_cb neigh_cb;
   void* neigh_curry;
   netstack_initial_e initial_events; // policy for initial object enumeration
-  // refrain from launching a thread to handle netlink events in the
-  // background. caller will need to handle nonblocking I/O. not yet used FIXME
-  bool no_thread;
 } netstack_opts;
 
 // Opts may be NULL, in which case the defaults will be used.

--- a/src/bin/demo.c
+++ b/src/bin/demo.c
@@ -19,7 +19,6 @@ int main(void){
     .route_curry = stdout,
     .neigh_cb = vnetstack_print_neigh,
     .neigh_curry = stdout,
-    .no_thread = false,
   };
   struct netstack* ns = netstack_create(&nopts);
   if(ns == NULL){

--- a/src/lib/netstack.c
+++ b/src/lib/netstack.c
@@ -574,10 +574,6 @@ validate_options(const netstack_opts* nopts){
   if(nopts == NULL){
     return true;
   }
-  if(nopts->no_thread){
-    fprintf(stderr, "Threadless mode is not yet supported\n"); // FIXME
-    return false;
-  }
   if(nopts->iface_curry && !nopts->iface_cb){
     return false;
   }


### PR DESCRIPTION
When we get a DEL message for ifaces, we need clean out both the hcache and the nametrie. This implements such cleaning (#29), as well as `name_trie_purge()` (#28).