### PR TITLE
Add rudimentary support for getting interrupt information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ target_compile_options(netstack
     -Wall -Wextra -W -Wshadow
     -D_POSIX_C_SOURCE=200809L # for strndup()
 )
+target_compile_definitions(netstack
+  PRIVATE
+   _DEFAULT_SOURCE
+)
 
 add_library(netstack-static STATIC ${LIBSRCS})
 target_include_directories(netstack-static PRIVATE include)
@@ -53,7 +57,6 @@ target_compile_options(netstack-static PRIVATE
   ${NL3_CFLAGS} ${NL3_CFLAGS_OTHER}
   -Wall -Wextra -W -Wshadow
 )
-
 file(GLOB BINSRCS CONFIGURE_DEPENDS src/bin/*.c)
 add_executable(netstack-demo ${BINSRCS})
 target_include_directories(netstack-demo PRIVATE include)

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -152,6 +152,9 @@ static inline bool netstack_iface_promisc(const struct netstack_iface* ni){
   return netstack_iface_flags(ni) & IFF_PROMISC;
 }
 
+// Get the IRQ corresponding to queue index qidx, or -1 on failure.
+int netstack_iface_irq(const struct netstack_iface* ni, unsigned qidx);
+
 // pass in the maximum number of bytes available for copying the link-layer
 // address. if this is sufficient, the actual number of bytes copied will be
 // stored to this variable. otherwise, NULL will be returned.

--- a/include/netstack.h
+++ b/include/netstack.h
@@ -152,8 +152,12 @@ static inline bool netstack_iface_promisc(const struct netstack_iface* ni){
   return netstack_iface_flags(ni) & IFF_PROMISC;
 }
 
-// Get the IRQ corresponding to queue index qidx, or -1 on failure.
+// Get the nth IRQ of the device, or -1 on failure. Currently only works for
+// directly-attached PCIe NICs using MSI.
 int netstack_iface_irq(const struct netstack_iface* ni, unsigned qidx);
+
+// Get the number of MSI interrupts for the device.
+unsigned netstack_iface_irqcount(const struct netstack_iface* ni);
 
 // pass in the maximum number of bytes available for copying the link-layer
 // address. if this is sufficient, the actual number of bytes copied will be

--- a/src/bin/demo.c
+++ b/src/bin/demo.c
@@ -5,6 +5,16 @@
 #include <stdlib.h>
 #include <netstack.h>
 
+static inline void
+print_iface(const struct netstack_iface* ni, netstack_event_e etype, void* vf){
+  vnetstack_print_iface(ni, etype, vf);
+  int irq = netstack_iface_irq(ni, 0);
+  if(irq >= 0){
+    printf("  IRQ: %d\n", irq);
+  }
+}
+
+
 int main(void){
   sigset_t sigset;
   sigemptyset(&sigset);
@@ -12,7 +22,7 @@ int main(void){
   sigaddset(&sigset, SIGINT);
   netstack_opts nopts = {
     .initial_events = NETSTACK_INITIAL_EVENTS_BLOCK,
-    .iface_cb = vnetstack_print_iface,
+    .iface_cb = print_iface,
     .iface_curry = stdout,
     .addr_cb = vnetstack_print_addr,
     .addr_curry = stdout,

--- a/src/bin/demo.c
+++ b/src/bin/demo.c
@@ -8,12 +8,16 @@
 static inline void
 print_iface(const struct netstack_iface* ni, netstack_event_e etype, void* vf){
   vnetstack_print_iface(ni, etype, vf);
-  int irq = netstack_iface_irq(ni, 0);
-  if(irq >= 0){
-    printf("  IRQ: %d\n", irq);
+  int irqcount = netstack_iface_irqcount(ni);
+  if(irqcount > 0){
+    int irq = netstack_iface_irq(ni, 0);
+    fprintf(vf, "      %d irq%s", irqcount, irqcount == 1 ? "" : "s");
+    if(irq >= 0){
+      fprintf(vf, ", base: %d", irq);
+    }
+    fprintf(vf, "\n");
   }
 }
-
 
 int main(void){
   sigset_t sigset;

--- a/src/lib/netstack.c
+++ b/src/lib/netstack.c
@@ -474,6 +474,11 @@ unsigned netstack_iface_count(const netstack* ns){
   return ret;
 }
 
+int netstack_iface_irq(const netstack_iface* ni, unsigned qidx){
+  // FIXME
+  return -1;
+}
+
 int netstack_iface_enumerate(const netstack* ns, uint32_t* offsets, int* n,
                              void* objs, size_t* obytes,
                              netstack_enumerator* streamer){


### PR DESCRIPTION
Use sysfs to get IRQ information for devices, exported through `netstack_iface_irq()` and `netstack_iface_irqcount()`. These functions assume that IRQs are contiguous for a device, which i'm not sure about. This only works thus far for directly-connected PCIe NICs making use of MSI. Closes #51.